### PR TITLE
🚑 Deno 1.4 support

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -3,7 +3,8 @@ import { cachedir } from "./directories.ts";
 import { File, FileWrapper, Origin, Policy, RELOAD_POLICY } from "./file.ts";
 import { toURL } from "./helpers.ts";
 
-export { File, Policy, Origin, RELOAD_POLICY };
+export type { File, Policy };
+export { Origin, RELOAD_POLICY };
 
 interface Options {
   directory: string | undefined;

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -1,6 +1,6 @@
 import { CacheError } from "./cache.ts";
 import { exists, join, resolve } from "./deps.ts";
-import { Metadata } from "./file.ts";
+import type { Metadata } from "./file.ts";
 import { protocol } from "./helpers.ts";
 
 async function protocolFile(url: URL, path: string): Promise<Metadata> {


### PR DESCRIPTION
There are a few imports that break under Deno 1.4 - this should solve the issues with the imports.