### PR TITLE
fix: use `fromFileUrl` to resolve paths (#4)

### DIFF
--- a/cache_test.ts
+++ b/cache_test.ts
@@ -53,6 +53,28 @@ Deno.test({
     assert(!(await local.exists(rel)));
   },
 });
+Deno.test({
+  name: "cache | local | url",
+  async fn(): Promise<void> {
+    const url = new URL("README.md", import.meta.url);
+
+    Cache.configure({
+      directory: "cache",
+    });
+    const local = Cache.namespace("local");
+    await local.purge();
+
+    assert(!(await local.exists(url)));
+
+    const file = await local.fetch(url);
+    assertEquals(file.origin, Cache.Origin.FETCH);
+
+    assert(await local.exists(url));
+
+    await local.remove(url);
+    assert(!(await local.exists(url)));
+  },
+});
 
 Deno.test({
   name: "cache | remote",

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -1,10 +1,10 @@
 import { CacheError } from "./cache.ts";
-import { exists, join, resolve } from "./deps.ts";
+import { exists, fromFileUrl } from "./deps.ts";
 import type { Metadata } from "./file.ts";
 import { protocol } from "./helpers.ts";
 
 async function protocolFile(url: URL, path: string): Promise<Metadata> {
-  const { pathname } = url;
+  const pathname = fromFileUrl(url);
   try {
     if (!(await exists(pathname))) {
       throw new CacheError(`${pathname} does not exist on the local system.`);


### PR DESCRIPTION
This is to fix #4. I've also added a test for it, but you can ignore that if you want.